### PR TITLE
Fix return value for `httpClientHandler.get()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-jsonld-document-loader ChangeLog
 
+## 1.2.2 - 2022-TBD
+
+### Fixed
+- Fix return value for `httpClientHandler.get()`.
+
 ## 1.2.1 - 2022-01-21
 
 ### Added

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,11 +27,7 @@ const httpClientHandler = {
       throw new Error('NotFoundError');
     }
 
-    return {
-      contextUrl: null,
-      document: result.data,
-      documentUrl: url
-    };
+    return result.data;
   }
 };
 

--- a/test/mocha/10-test.js
+++ b/test/mocha/10-test.js
@@ -106,12 +106,8 @@ describe('httpClientHandler', () => {
     assertNoError(error);
     should.exist(result);
     result.should.eql({
-      contextUrl: null,
-      document: {
-        '@context': 'https://schema.org/',
-        name: 'John Doe'
-      },
-      documentUrl: `${BASE_URL}/documents/json`
+      '@context': 'https://schema.org/',
+      name: 'John Doe'
     });
   });
   it('throws error if url does not start with "http"', async () => {


### PR DESCRIPTION
I noticed that in `httpClientHandler.get()`, we were wrapping the result inside of

```
{
    contextUrl: null,
    document: result.data,
    documentUrl: url
}
```

but we are also doing that here - https://github.com/digitalbazaar/jsonld-document-loader/blob/main/lib/JsonLdDocumentLoader.js#L59-L75

This was causing this test https://github.com/digitalbazaar/bedrock-vc-verifier/blob/update-documentLoader/test/mocha/40-credential-status.js#L221 to fail, so I wasn't sure that we needed both, so I've removed it here. 